### PR TITLE
fix: update project name from AI Shell to AIsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Shell 🚀
+# AIsh 🚀
 
 An intelligent shell wrapper that enhances your command-line experience using AI. It seamlessly handles both shell commands and natural language queries, providing helpful suggestions and corrections when needed.
 
@@ -15,8 +15,8 @@ An intelligent shell wrapper that enhances your command-line experience using AI
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/yourusername/ai-shell.git
-cd ai-shell
+git clone https://github.com/yourusername/aish.git
+cd aish
 ```
 
 2. Install dependencies:
@@ -35,7 +35,7 @@ OPENAI_API_KEY=your_api_key_here
 
 ## Usage
 
-Run the AI shell:
+Run AIsh:
 ```bash
 node index.js
 ```
@@ -64,7 +64,7 @@ ai-shell> git stats
 ### Keyboard Shortcuts
 
 - `Ctrl+C`: Exit running command (or exit shell if no command is running)
-- `exit` or `quit`: Exit the AI shell
+- `exit` or `quit`: Exit AIsh
 
 ## Requirements
 


### PR DESCRIPTION
Change the project name throughout the README from "AI Shell" to 
"AIsh" to reflect the new branding. Update installation instructions 
and usage examples accordingly for consistency.